### PR TITLE
Add a carriage return for WinOS

### DIFF
--- a/mapdownload.sp
+++ b/mapdownload.sp
@@ -3163,7 +3163,7 @@ public OnExtracted(const String:output[], const size, CMDReturn:status)
 									// Add a carriage return as line ending for WindowsOS
 									if (System2_GetOS() == OS_WINDOWS)
 									{
-										Format(content, sizeof(content), "%s\r", content);
+										StrCat(content, sizeof(content), "\r");
 									}
 
 									WriteFileLine(file, content);
@@ -3401,6 +3401,11 @@ SearchForFolders(String:path[], found)
 							// If not in mapcycle, add it
 							if (!duplicate)
 							{
+								// Add a carriage return as line ending for WindowsOS
+								if (System2_GetOS() == OS_WINDOWS)
+								{
+									StrCat(content, sizeof(content), "\r");
+								}
 								WriteFileLine(mapcycle, content);
 							}
 

--- a/mapdownload.sp
+++ b/mapdownload.sp
@@ -3157,10 +3157,16 @@ public OnExtracted(const String:output[], const size, CMDReturn:status)
 								// If not in file already, add it
 								if (!duplicate)
 								{
-									WriteFileLine(file, content);
-
 									// Add to download table
 									AddFileToDownloadsTable(content);
+
+									// Add a carriage return as line ending for WindowsOS
+									if (System2_GetOS() == OS_WINDOWS)
+									{
+										Format(content, sizeof(content), "%s\r", content);
+									}
+
+									WriteFileLine(file, content);
 								}
 							}
 						}


### PR DESCRIPTION
Add a carriage return as line ending for Windows Server compatibility. http://www.cs.toronto.edu/~krueger/csc209h/tut/line-endings.html